### PR TITLE
WIP: upsilon/Chinachu 変更点まとめ

### DIFF
--- a/api/script-channel-watch.vm.js
+++ b/api/script-channel-watch.vm.js
@@ -23,6 +23,9 @@ Usushio では使わない
 			var ext    = request.query.ext || 'm2ts';
 			var prefix = request.query.prefix || '';
 
+			// BASIC 認証の ユーザ名:パスワード の組を URL に含める
+			prefix = prefix.replace(/^https?:\/\//, '$&' + config.wuiUsers[0] + '@');
+
 			var target = prefix + 'watch.' + ext  + url.parse(request.url).search;
 
 			response.write('<?xml version="1.0" encoding="UTF-8"?>\n');

--- a/api/script-recorded-program-preview.vm.js
+++ b/api/script-recorded-program-preview.vm.js
@@ -44,7 +44,7 @@
 	
 	var ffmpeg = child_process.exec(
 		(
-			'ffmpeg -f mpegts -ss ' + pos + ' -r 10 -i "' + program.recorded + '" -ss 1.5 -r 10 -frames:v 1' +
+			'ffmpeg -f mpegts -ss ' + pos + ' -r 10 -i "' + program.recorded + '" -ss 1.5 -r 10 -vf yadif -frames:v 1' +
 			' -c:v ' + vcodec + ' -an -f image2 -s ' + width + 'x' + height + ' -map 0:0 -y pipe:1'
 		)
 		,

--- a/api/script-recorded-program-watch.vm.js
+++ b/api/script-recorded-program-watch.vm.js
@@ -44,6 +44,9 @@ function main(avinfo) {
 			var ext    = request.query.ext || 'm2ts';
 			var prefix = request.query.prefix || '';
 
+			// BASIC 認証の ユーザ名:パスワード の組を URL に含める
+			prefix = prefix.replace(/^https?:\/\//, '$&' + config.wuiUsers[0] + '@');
+
 			var target = prefix + 'watch.' + ext  + url.parse(request.url).search;
 
 			response.write('<?xml version="1.0" encoding="UTF-8"?>\n');

--- a/api/script-recording-program-preview.vm.js
+++ b/api/script-recording-program-preview.vm.js
@@ -38,7 +38,7 @@
 	var ffmpeg = child_process.exec(
 		(
 			'tail -c 3200000 "' + program.recorded + '" | ' +
-			'ffmpeg -f mpegts -r 10 -i pipe:0 -ss 1.5 -r 10 -frames:v 1 -f image2 -codec:v ' + vcodec +
+			'ffmpeg -f mpegts -r 10 -i pipe:0 -ss 1.5 -r 10 -vf yadif -frames:v 1 -f image2 -codec:v ' + vcodec +
 			' -an -s ' + width + 'x' + height + ' -map 0:0 -y pipe:1'
 		)
 		,

--- a/api/script-recording-program-watch.vm.js
+++ b/api/script-recording-program-watch.vm.js
@@ -24,6 +24,9 @@
 			var ext    = request.query.ext || 'm2ts';
 			var prefix = request.query.prefix || '';
 
+			// BASIC 認証の ユーザ名:パスワード の組を URL に含める
+			prefix = prefix.replace(/^https?:\/\//, '$&' + config.wuiUsers[0] + '@');
+
 			var target = prefix + 'watch.' + ext  + url.parse(request.url).search;
 
 			response.write('<?xml version="1.0" encoding="UTF-8"?>\n');

--- a/processes.json
+++ b/processes.json
@@ -4,32 +4,32 @@
       "name": "chinachu-wui",
       "script": "app-wui.js",
       "node_args" : "",
-      "error_file": "/usr/local/var/log/chinachu-wui.stderr.log",
-      "out_file": "/usr/local/var/log/chinachu-wui.stdout.log",
+      "error_file": "/usr/local/var/log/chinachu/wui.stderr.log",
+      "out_file": "/usr/local/var/log/chinachu/wui.stdout.log",
       "merge_logs": true,
-      "pid_file": "/usr/local/var/run/chinachu-wui.pid",
+      "pid_file": "/usr/local/var/run/chinachu/wui.pid",
       "exec_mode": "fork",
       "autorestart": true,
       "env": {
         "NODE_ENV": "production",
-        "LOG_STDOUT": "/usr/local/var/log/chinachu-wui.stdout.log",
-        "LOG_STDERR": "/usr/local/var/log/chinachu-wui.stderr.log"
+        "LOG_STDOUT": "/usr/local/var/log/chinachu/wui.stdout.log",
+        "LOG_STDERR": "/usr/local/var/log/chinachu/wui.stderr.log"
       }
     },
     {
       "name": "chinachu-operator",
       "script": "app-operator.js",
       "node_args" : "",
-      "error_file": "/usr/local/var/log/chinachu-operator.stderr.log",
-      "out_file": "/usr/local/var/log/chinachu-operator.stdout.log",
+      "error_file": "/usr/local/var/log/chinachu/operator.stderr.log",
+      "out_file": "/usr/local/var/log/chinachu/operator.stdout.log",
       "merge_logs": true,
-      "pid_file": "/usr/local/var/run/chinachu-operator.pid",
+      "pid_file": "/usr/local/var/run/chinachu/operator.pid",
       "exec_mode": "fork",
       "autorestart": true,
       "env": {
         "NODE_ENV": "production",
-        "LOG_STDOUT": "/usr/local/var/log/chinachu-operator.stdout.log",
-        "LOG_STDERR": "/usr/local/var/log/chinachu-operator.stderr.log"
+        "LOG_STDOUT": "/usr/local/var/log/chinachu/operator.stdout.log",
+        "LOG_STDERR": "/usr/local/var/log/chinachu/operator.stderr.log"
       }
     }
   ]


### PR DESCRIPTION
master との差分を解説する用のPull Request

- [x] XSPFの location にBASIC認証のパスワード等を含める
  - VLCがBASIC認証のパスワードを覚えてくれないのに嫌気が差した
- [x] ディレクトリ構成を変更
  - upsilon/Mirakurun#1 に合わせて `/usr/local/var/log/chinachu/*.log` とかに移動
- [x] サムネイル画像出力時にインターレース解除する

Mirakurunはこっち: upsilon/Mirakurun#1